### PR TITLE
Revert pathSegmentsToKeep to 0

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -23,7 +23,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 1;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
This PR attempts to resolve a redirect issue potentially caused by `pathSegmentsToKeep` being set to `1`.